### PR TITLE
Fix spelling in configuration man page

### DIFF
--- a/source/doc/manuals/man-configuration.html.erb
+++ b/source/doc/manuals/man-configuration.html.erb
@@ -8,13 +8,13 @@ layout: doc
   You can find all the configuration files in <b>src/conf</b> directory.
 </p>
 <p>
-  The files are loaded in alphabetical order (that is why they are prefixed with a number) and merged togheter into one final map.
+  The files are loaded in alphabetical order (which is why they are prefixed with a number) and merged together into one final map.
 </p>
 <p>
-  It is highly encouraged that you write your own files instead of modifiying the provided ones (because they may be affected by updates).
+  It is highly encouraged that you write your own files instead of modifying the provided ones (because they may be affected by updates).
 </p>
 <p>
-  I provide a <a href="https://raw.githubusercontent.com/andersevenrud/OS.js-v2/master/src/templates/conf/900-custom.json">example</a> in the repository.
+  I provide an <a href="https://raw.githubusercontent.com/andersevenrud/OS.js-v2/master/src/templates/conf/900-custom.json">example</a> in the repository.
 </p>
 
 <p>


### PR DESCRIPTION
Now in the right repo.
