### PR TITLE
Fixed Typo in Command to Build

### DIFF
--- a/src/manual/corewm/index.md
+++ b/src/manual/corewm/index.md
@@ -41,7 +41,7 @@ See the included font theme for an example on how to set up.
 
 ```bash
 $ edit src/conf/112-themes.json # Or create your own file
-$ node osjs build:config buid:theme --fonts
+$ node osjs build:config build:theme --fonts
 ```
 
 ---

--- a/src/manual/package/application/index.md
+++ b/src/manual/package/application/index.md
@@ -31,5 +31,5 @@ $ node osjs generate:package --name=default/MyName --type=simple
 ## Building and installation
 
 ```bash
-$ node osjs build:manifest buid:config build:package --name=default/MyName
+$ node osjs build:manifest build:config build:package --name=default/MyName
 ```

--- a/src/manual/package/extension/index.md
+++ b/src/manual/package/extension/index.md
@@ -25,5 +25,5 @@ $ node osjs generate:package --name=default/MyName --type=extension
 ## Building and installation
 
 ```bash
-$ node osjs build:manifest buid:config build:package --name=default/MyName
+$ node osjs build:manifest build:config build:package --name=default/MyName
 ```

--- a/src/manual/package/iframe/index.md
+++ b/src/manual/package/iframe/index.md
@@ -39,5 +39,5 @@ You can communicate between OS.js and your IFrame application using the browser 
 ## Building and installation
 
 ```bash
-$ node osjs build:manifest buid:config build:package --name=default/MyName
+$ node osjs build:manifest build:config build:package --name=default/MyName
 ```

--- a/src/manual/package/service/index.md
+++ b/src/manual/package/service/index.md
@@ -25,5 +25,5 @@ $ node osjs generate:package --name=default/MyName --type=service
 ## Building and installation
 
 ```bash
-$ node osjs build:manifest buid:config build:package --name=default/MyName
+$ node osjs build:manifest build:config build:package --name=default/MyName
 ```


### PR DESCRIPTION
Fixed typo in commands to build and install some packages. (CoreWM Font,
Application, Extension, IFrame, Service)