### PR TITLE
Automatically updates the copyright every year

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -220,6 +220,12 @@
       };
     </script>
     <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+    <script>
+	//Automatically keep the copyright up to date
+	var copyright =  document.querySelector('footer').querySelector("p");
+        var copyText = copyright.innerHTML; 
+        copyright.innerHTML = copyText.replace(/\d+-\d+/,("2011-"+(new Date()).getFullYear())); 
+    </script>
 
 
   </body>


### PR DESCRIPTION
Saw a manual change in issue #8 and decided maybe the site should update itself automatically. Up to you to agree or disagree, but here's an implementation of it.

Uses regex on hardcoded copyright date to replace it. 